### PR TITLE
bootstrap: Fix for new dll name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ If you have a Resonite prerelease install inside the default steamapps directory
 
 You can also change the dotnet executable with `--executable <path>`. Resonite args are specified after `--resoniteargs`.
 
-### Run Resonite.dll separately
-By default Renderite.Godot handles launching Resonite for you. If you'd like to launch it independently you can use `--noautolaunch`, which will simply print out the shmprefix you have to give to Resonite.dll:
+### Run Renderite.Host.dll separately
+By default Renderite.Godot handles launching Resonite for you. If you'd like to launch it independently you can use `--noautolaunch`, which will simply print out the shmprefix you have to give to Renderite.Host.dll:
 ```
-dotnet Resonite.dll -shmprefix <prefix here> -LoadAssembly Libraries/ResoniteModLoader.dll
+dotnet Renderite.Host.dll -shmprefix <prefix here> -LoadAssembly Libraries/ResoniteModLoader.dll
 ```

--- a/Source/RendererManager.cs
+++ b/Source/RendererManager.cs
@@ -80,7 +80,7 @@ public partial class RendererManager : Node
         if (launchResonite)
         {
             GD.Print($"Resonite path: {resonitePath}");
-            var dllPath = System.IO.Path.Combine(resonitePath, "Resonite.dll");
+            var dllPath = System.IO.Path.Combine(resonitePath, "Renderite.Host.dll");
             var resoniteArgs = args.SkipWhile(arg => arg.ToLower() != "--resoniteargs").Skip(1).ToArray().Join(" ");
             var startInfo = new ProcessStartInfo
             {
@@ -116,7 +116,7 @@ public partial class RendererManager : Node
         }
         else
         {
-            GD.Print($"Resonite auto launch disabled, please run Resonite.dll manually with -shmprefix {shmPrefix}");
+            GD.Print($"Resonite auto launch disabled, please run Renderite.Host.dll manually with -shmprefix {shmPrefix}");
         }
     }
     public override void _Notification(int what)


### PR DESCRIPTION
This updates the `Resonite.dll` name to `Renderite.Host.dll`, which is the new name as of `2025.8.12.113`.